### PR TITLE
Show loader when query params change

### DIFF
--- a/src/appDir.tsx
+++ b/src/appDir.tsx
@@ -111,6 +111,7 @@ export const AppProgressBar = React.memo(
 
     useEffect(() => {
       NProgress.done();
+      return () => NProgress.start();
     }, [pathname, searchParams]);
 
     useEffect(() => {


### PR DESCRIPTION
This simple solution should fixes #21 where loader doesn't show when search params changed.
When useEffect unmounted means the user navigated away from the previous page,
it will should start the loading and stop when next dependency update (page changed).