### PR TITLE
Flag to disable anchor link handlers from being attached

### DIFF
--- a/src/AppProgressBar.tsx
+++ b/src/AppProgressBar.tsx
@@ -29,6 +29,7 @@ export const AppProgressBar = React.memo(
     style,
     nonce,
     targetPreprocessor,
+    disableAnchorClick = false,
   }: ProgressBarProps) => {
     const styles = (
       <style nonce={nonce}>
@@ -126,6 +127,10 @@ export const AppProgressBar = React.memo(
 
     const elementsWithAttachedHandlers = useRef<(HTMLAnchorElement | SVGAElement)[]>([])
     useEffect(() => {
+      if (disableAnchorClick) {
+        return;
+      }
+
       let timer: NodeJS.Timeout;
 
       const startProgress = () => {
@@ -254,7 +259,8 @@ export const AppProgressBar = React.memo(
       prevProps?.nonce === nextProps?.nonce &&
       JSON.stringify(prevProps?.options) ===
         JSON.stringify(nextProps?.options) &&
-      prevProps?.style === nextProps?.style
+      prevProps?.style === nextProps?.style &&
+      prevProps.disableAnchorClick === nextProps.disableAnchorClick
     );
   },
 );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,6 +31,7 @@ export interface NProgressOptions {
  * @param nonce Custom nonce for Content-Security-Policy directives - @default undefined
  * @param shouldCompareComplexProps If you want to compare props in the React.memo return - @default false
  * @param targetPreprocessor If you want to./AppProgressBaress the target URL - @default undefined
+ * @param disableAnchorClick Disable triggering progress bar on anchor clicks - @default false
  */
 export interface ProgressBarProps {
   color?: string;
@@ -46,6 +47,7 @@ export interface ProgressBarProps {
   memo?: boolean;
   shouldCompareComplexProps?: boolean;
   targetPreprocessor?: (url: URL) => URL;
+  disableAnchorClick?: boolean;
 }
 
 export interface RouterNProgressOptions {


### PR DESCRIPTION
Based on top of #59 

Adds a flag to the progress bar that allows you to disable the anchor click handlers.

### TODO

- [ ] do this for pages router. I didn't implement it for now, since I don't use the pages router.

In my case, I am using this workaround from [a NextJS discussion where one monkey-patches the app router implementation](https://github.com/vercel/next.js/discussions/47020#discussioncomment-8999386) to allow for blocking navigation.

But since this library just adds event handlers to every link, while page transitions do properly get blocked, the progress bar starts regardless and then just runs forever.

So I combined the above code with a context/provider to register when navigation has been intercepted; and then based on the intercept status, disable the anchor bindings for `nprogress`. This way, it all works and no issues with mystery progress bars.