### PR TITLE
Fix handleMutation useEffect not updating when props update; not properly detaching handlers

### DIFF
--- a/src/AppProgressBar.tsx
+++ b/src/AppProgressBar.tsx
@@ -232,12 +232,12 @@ export const AppProgressBar = React.memo(
       return () => {
         mutationObserver.disconnect();
         elementsWithAttachedHandlers.current.forEach((anchor) => {
-          anchor.removeEventListener('click', handleAnchorClick);
+          anchor.removeEventListener('click', handleAnchorClick, true);
         });
         elementsWithAttachedHandlers.current = [];
         window.history.pushState = originalWindowHistoryPushState;
       };
-    }, []);
+    }, [disableAnchorClick, targetPreprocessor, shallowRouting, disableSameURL]);
 
     return styles;
   },


### PR DESCRIPTION
Also, realized that changing the props doesn't cause this to be triggered unless you pass `shouldCompareComplexProps` as well, or disable memoization.