### PR TITLE
Bugfix for delay parameter

### DIFF
--- a/src/AppProgressBar.tsx
+++ b/src/AppProgressBar.tsx
@@ -147,6 +147,7 @@ export const AppProgressBar = React.memo(
       const stopProgress = () => {
         if (timer) clearTimeout(timer);
         timer = setTimeout(() => {
+          if (!NProgress.isStarted()) return;
           NProgress.done();
         }, stopDelay);
       };

--- a/src/PagesProgressBar.tsx
+++ b/src/PagesProgressBar.tsx
@@ -123,7 +123,7 @@ export const PagesProgressBar = React.memo(
 
         if (
           !shallowRouting ||
-          (!isSameURL(targetUrl, currentUrl) && disableSameURL)
+          (isSameURL(targetUrl, currentUrl) && !disableSameURL)
         ) {
           startProgress();
         }

--- a/src/PagesProgressBar.tsx
+++ b/src/PagesProgressBar.tsx
@@ -112,6 +112,7 @@ export const PagesProgressBar = React.memo(
       const stopProgress = () => {
         if (timer) clearTimeout(timer);
         timer = setTimeout(() => {
+          if (!NProgress.isStarted()) return;
           NProgress.done(true);
         }, stopDelay);
       };


### PR DESCRIPTION
As of right now, no matter if you have `delay` or `stopDelay` set, `NProgress.done()` will always get called in the `stopProgress()` handler which causes the progress bar to flash as if completion happened:
![CleanShot 2024-10-09 at 22 47 06](https://github.com/user-attachments/assets/d63c8bab-0c9a-440e-ae3d-532db6c1dbe5)

This also fixes the condition for the `disableSameURL` setting in the `PagesProgressBar` which is negated in the wrong spot.

Addresses https://github.com/Skyleen77/next-nprogress-bar/issues/46