### PR TITLE
fix: PagesProgressBar shallowRouting

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ See [NProgress docs](https://www.npmjs.com/package/nprogress#configuration)
 
 ### shallowRouting _optional_ - _boolean_
 
-If the progress bar is not displayed when you only change URL parameters without changing route - **by default false**
+Do not display the progress bar when the query parameters change but the route remains the same - **by default false**
 
 See [Next.js docs](https://nextjs.org/docs/pages/building-your-application/routing/linking-and-navigating#shallow-routing)
 

--- a/src/PagesProgressBar.tsx
+++ b/src/PagesProgressBar.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import NProgress from 'nprogress';
-import { isSameURL } from './utils/sameURL';
+import { isSameURL, isSameURLWithoutSearch } from './utils/sameURL';
 import Router from 'next/router';
 import { ProgressBarProps } from '.';
 
@@ -122,13 +122,14 @@ export const PagesProgressBar = React.memo(
         const currentUrl = new URL(Router.route, location.href);
 
         if (
-          (!shallowRouting ||
-            (isSameURL(targetUrl, currentUrl) && !disableSameURL) ||
-            !isSameURL(targetUrl, currentUrl)) &&
-          !NProgress.isStarted()
-        ) {
-          startProgress();
-        }
+            shallowRouting &&
+            isSameURLWithoutSearch(targetUrl, currentUrl) &&
+            disableSameURL
+        )
+          return;
+        if (isSameURL(targetUrl, currentUrl) && disableSameURL) return;
+
+        startProgress();
       };
       const handleRouteDone = () => stopProgress();
 


### PR DESCRIPTION
## Description

This matches the logic that is contained in `AppProgressBar` for `shallowRouting`.

Closes #68 