### PR TITLE
fix: use asPath instead of route for shallowRouting comparison

### DIFF
--- a/src/PagesProgressBar.tsx
+++ b/src/PagesProgressBar.tsx
@@ -52,7 +52,7 @@ export const PagesProgressBar = React.memo(
 
       const handleRouteStart = (url: string) => {
         const targetUrl = new URL(url, location.href);
-        const currentUrl = new URL(Router.route, location.href);
+        const currentUrl = new URL(Router.asPath, location.href);
 
         if (
           shallowRouting &&

--- a/src/PagesProgressBar.tsx
+++ b/src/PagesProgressBar.tsx
@@ -52,7 +52,7 @@ export const PagesProgressBar = React.memo(
 
       const handleRouteStart = (url: string) => {
         const targetUrl = new URL(url, location.href);
-        const currentUrl = new URL(Router.asPath, location.href);
+        const currentUrl = new URL(location.href);
 
         if (
           shallowRouting &&


### PR DESCRIPTION
Closes #82 

After merging https://github.com/Skyleen77/next-nprogress-bar/pull/81 I ran test with `shallowRouting` and `disableSameURL`.

It works to the exception of routes which have variable parameters in there.

The issue is with this logic:
https://github.com/Skyleen77/next-nprogress-bar/blob/50aae80d4207addea77e9bb082cdee49b44ab283/src/PagesProgressBar.tsx#L54C1-L55C65

`Router.route` returns the template version of the route while the href contains the templated version:
```json
{
  "currentUrl": "http://localhost:3000/posts/[postId]"
  "targetUrl": "http://localhost:3000/posts/de64b4ce-cc79-443b-975b-c886fffa7cf1"
}
