### PR TITLE
Fix typo in docs/upgrade

### DIFF
--- a/apps/docs/content/docs/upgrade.mdx
+++ b/apps/docs/content/docs/upgrade.mdx
@@ -1,5 +1,5 @@
 ---
-title: Upgrade form 1.0 to 1.3
+title: Upgrade from 1.0 to 1.3
 description: Upgrade from NProgress-V2 version 1.0 to BProgress version 1.3
 ---
 


### PR DESCRIPTION
Was just reading the docs when I noticed on the page about upgrading from 1.0 to 1.3, there was a slight typo. The page title is "Upgrade form 1.0 to 1.3" when it should be "Upgrade from 1.0 to 1.3"